### PR TITLE
VAP-95 remove today text replacement

### DIFF
--- a/routines/SAMIFRM2.m
+++ b/routines/SAMIFRM2.m
@@ -426,11 +426,6 @@ SAMISUB2(line,form,sid,filter,%j,zhtml) ; used for Dom's new style forms
  if line["VEP0001" do  ;
  . do findReplace^%ts(.line,"VEP0001",sid,"a")
  ;
- ;if line["01/Mar/2018" do  ;
- ;. n ztoday s ztoday=$$FMTE^XLFDT($$NOW^XLFDT,"9D")
- ;. s ztoday=$tr(ztoday," ","/")
- ;. d findReplace^%ts(.line,"01/Mar/2018",ztoday)
- ;
  quit  ; end of SAMISUB2
  ;
 wsSbform(rtn,filter) ; background form access


### PR DESCRIPTION
This commit removes the code that was previously used to replace a hard-coded date in the HTML templates with "today". This is no longer needed as "today" is now calculated by the web browser. 
Note, that this code in M was commented out. There is no need to keep this however so it was deleted entirely. 