### PR TITLE
VAP-163 : set initial state of require one validator

### DIFF
--- a/docs/www/init.js
+++ b/docs/www/init.js
@@ -37,6 +37,9 @@ function requireOneValidator($fields, $validatorControl) {
         // validators should be enabled when triggered.
         $validatorControl.data("fv-fields", $fields);
 
+        // set the initial value of the field to the state of the watched fields
+        $validatorControl.val($fields.filter(":checked").length);
+        
         $fields.on('change', function () {
             $validatorControl.val($fields.filter(":checked").length);
             fv.revalidateField($validatorControl);


### PR DESCRIPTION
The require one validator did not set the initial state of the validator to what was initially selected on the form, but only reacted to the changes on the page. 