### PR TITLE
VAP-271 removed selected attribute on "-" option for breast density classification fields

### DIFF
--- a/docs/src/ctevaluation.html.jinja2
+++ b/docs/src/ctevaluation.html.jinja2
@@ -1456,7 +1456,7 @@
                                         <div class="form-group">
                                             <select name="ceobard" class="form-control"
                                                     title="Right Breast Density Classification">
-                                                <option value="-" SELECTED> -</option>
+                                                <option value="-"> -</option>
                                                 <option value="1"> 1 - Almost entirely fatty</option>
                                                 <option value="2"> 2 - Scattered areas of fibroglandular density
                                                 </option>
@@ -1491,7 +1491,7 @@
                                         <div class="form-group">
                                             <select name="ceobald" class="form-control"
                                                     title="Left Breast Density Classification">
-                                                <option value="-" SELECTED> -</option>
+                                                <option value="-"> -</option>
                                                 <option value="1"> 1 - Almost entirely fatty</option>
                                                 <option value="2"> 2 - Scattered areas of fibroglandular density
                                                 </option>


### PR DESCRIPTION
The SELECTED attribute was messing up the final HTML causing it to look like there was no option to select "-". This fixes that.